### PR TITLE
fix: boot cache during register()

### DIFF
--- a/src/Providers/LaravelSymfonyCacheServiceProvider.php
+++ b/src/Providers/LaravelSymfonyCacheServiceProvider.php
@@ -19,22 +19,24 @@ use Trevorpe\LaravelSymfonyCache\Cache\SymfonyTagAwareCacheStore;
 
 class LaravelSymfonyCacheServiceProvider extends ServiceProvider
 {
-    public function boot()
+    public function register()
     {
         $serviceProvider = $this;
 
-        Cache::extend(
-            'symfony',
-            function (Application $app, array $config) use ($serviceProvider) {
-                $adapter = $serviceProvider->createAdapterFromConfig($config);
+        $this->app->booting(function () use ($serviceProvider) {
+            Cache::extend(
+                'symfony',
+                function (Application $app, array $config) use ($serviceProvider) {
+                    $adapter = $serviceProvider->createAdapterFromConfig($config);
 
-                $store = $adapter instanceof TagAwareAdapterInterface
-                    ? new SymfonyTagAwareCacheStore($adapter)
-                    : new SymfonyCacheStore($adapter);
+                    $store = $adapter instanceof TagAwareAdapterInterface
+                        ? new SymfonyTagAwareCacheStore($adapter)
+                        : new SymfonyCacheStore($adapter);
 
-                return Cache::repository($store);
-            }
-        );
+                    return Cache::repository($store);
+                }
+            );
+        });
     }
 
     public function createAdapterFromConfig(array $config): AdapterInterface


### PR DESCRIPTION
## Description

Register the cache driver during the `register()` method of the service provider. This ensures that other service providers can use the Symfony cache within their `boot()` method (see [Laravel Docs][1]).

## Links

1. [Laravel Docs][1]
2. [Previous Issue][2]

[1]: https://laravel.com/docs/11.x/cache#registering-the-driver
[2]: https://github.com/trevorpe/laravel-symfony-cache/issues/14