### PR TITLE
refactor: extract Redis-specific stores

### DIFF
--- a/src/Cache/SymfonyCacheFactory.php
+++ b/src/Cache/SymfonyCacheFactory.php
@@ -4,15 +4,23 @@ namespace Trevorpe\LaravelSymfonyCache\Cache;
 
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\Store;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use TypeError;
 
 class SymfonyCacheFactory
 {
+    protected Container $container;
+
     protected SymfonyCacheAdapterFactory $adapterFactory;
 
-    public function __construct(SymfonyCacheAdapterFactory $adapterFactory)
+    public function __construct(Container $container, SymfonyCacheAdapterFactory $adapterFactory)
     {
+        $this->container = $container;
         $this->adapterFactory = $adapterFactory;
     }
 
@@ -23,10 +31,34 @@ class SymfonyCacheFactory
 
     public function storeFromConfig(array $config): Store
     {
+        $desiredAdapter = $config['adapter'];
+
+        if (in_array($desiredAdapter, [RedisAdapter::class, RedisTagAwareAdapter::class])) {
+            return $this->storeFromRedisConfig($config);
+        }
+
         $adapter = $this->adapterFactory->createAdapterFromConfig($config);
 
         return $adapter instanceof TagAwareAdapterInterface
             ? new SymfonyTagAwareCacheStore($adapter)
             : new SymfonyCacheStore($adapter);
+    }
+
+    protected function storeFromRedisConfig(array $redisConfig): Store
+    {
+        $desiredAdapter = $redisConfig['adapter'];
+        $tagAware = $redisConfig['tag_aware'] ?? null;
+
+        if (!in_array($desiredAdapter, [RedisAdapter::class, RedisTagAwareAdapter::class])) {
+            throw new TypeError("unsupported redis adapter $desiredAdapter provided");
+        }
+
+        $args = Arr::pluck($redisConfig, ['prefix', 'connection']);
+
+        if ($desiredAdapter === RedisTagAwareAdapter::class || $tagAware) {
+            return $this->container->make(SymfonyTagAwareRedisStore::class, $args);
+        } else {
+            return $this->container->make(SymfonyRedisStore::class, $args);
+        }
     }
 }

--- a/src/Cache/SymfonyRedisCacheTrait.php
+++ b/src/Cache/SymfonyRedisCacheTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Trevorpe\LaravelSymfonyCache\Cache;
+
+use Illuminate\Contracts\Redis\Factory;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+
+trait SymfonyRedisCacheTrait
+{
+    protected Factory $redis;
+
+    protected string $prefix = '';
+
+    protected string $connection = 'default';
+
+    abstract protected function createRedisAdapter(): AdapterInterface;
+
+    /**
+     * @return mixed|\Redis
+     */
+    public function client()
+    {
+        return $this->connection()->client();
+    }
+
+    /**
+     * @return \Illuminate\Redis\Connections\Connection
+     */
+    public function connection()
+    {
+        return $this->redis->connection($this->connection);
+    }
+
+    /**
+     * Specify the name of the connection that should be used to store data.
+     *
+     * @param  string  $connection
+     * @return static
+     */
+    public function setConnection($connection)
+    {
+        $this->connection = $connection;
+        $this->cacheAdapter = $this->createRedisAdapter();
+        return $this;
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->prefix;
+    }
+
+    public function setPrefix(string $prefix): static
+    {
+        $this->prefix = $prefix;
+        return $this;
+    }
+}

--- a/src/Cache/SymfonyRedisCacheTrait.php
+++ b/src/Cache/SymfonyRedisCacheTrait.php
@@ -9,9 +9,9 @@ trait SymfonyRedisCacheTrait
 {
     protected Factory $redis;
 
-    protected string $prefix = '';
+    protected ?string $prefix = null;
 
-    protected string $connection = 'default';
+    protected ?string $connection = null;
 
     abstract protected function createRedisAdapter(): AdapterInterface;
 
@@ -46,10 +46,10 @@ trait SymfonyRedisCacheTrait
 
     public function getPrefix(): string
     {
-        return $this->prefix;
+        return $this->prefix ?? '';
     }
 
-    public function setPrefix(string $prefix): static
+    public function setPrefix(?string $prefix): static
     {
         $this->prefix = $prefix;
         return $this;

--- a/src/Cache/SymfonyRedisStore.php
+++ b/src/Cache/SymfonyRedisStore.php
@@ -9,7 +9,7 @@ class SymfonyRedisStore extends SymfonyCacheStore
 {
     use SymfonyRedisCacheTrait;
 
-    public function __construct(Factory $redis, string $prefix = '', string $connection = 'default')
+    public function __construct(Factory $redis, ?string $prefix = null, ?string $connection = null)
     {
         $this->redis = $redis;
         $this->setPrefix($prefix);

--- a/src/Cache/SymfonyRedisStore.php
+++ b/src/Cache/SymfonyRedisStore.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Trevorpe\LaravelSymfonyCache\Cache;
+
+use Illuminate\Contracts\Redis\Factory;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
+class SymfonyRedisStore extends SymfonyCacheStore
+{
+    use SymfonyRedisCacheTrait;
+
+    public function __construct(Factory $redis, string $prefix = '', string $connection = 'default')
+    {
+        $this->redis = $redis;
+        $this->setPrefix($prefix);
+        $this->setConnection($connection);
+
+        parent::__construct($this->createRedisAdapter());
+    }
+
+    private function createRedisAdapter(): RedisAdapter
+    {
+        return new RedisAdapter($this->client(), $this->getPrefix());
+    }
+}

--- a/src/Cache/SymfonyTagAwareRedisStore.php
+++ b/src/Cache/SymfonyTagAwareRedisStore.php
@@ -9,7 +9,7 @@ class SymfonyTagAwareRedisStore extends SymfonyTagAwareCacheStore
 {
     use SymfonyRedisCacheTrait;
 
-    public function __construct(Factory $redis, string $prefix = '', string $connection = 'default')
+    public function __construct(Factory $redis, ?string $prefix = null, ?string $connection = null)
     {
         $this->redis = $redis;
         $this->setPrefix($prefix);

--- a/src/Cache/SymfonyTagAwareRedisStore.php
+++ b/src/Cache/SymfonyTagAwareRedisStore.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Trevorpe\LaravelSymfonyCache\Cache;
+
+use Illuminate\Contracts\Redis\Factory;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
+
+class SymfonyTagAwareRedisStore extends SymfonyTagAwareCacheStore
+{
+    use SymfonyRedisCacheTrait;
+
+    public function __construct(Factory $redis, string $prefix = '', string $connection = 'default')
+    {
+        $this->redis = $redis;
+        $this->setPrefix($prefix);
+        $this->setConnection($connection);
+
+        parent::__construct($this->createRedisAdapter());
+    }
+
+    private function createRedisAdapter(): RedisTagAwareAdapter
+    {
+        return new RedisTagAwareAdapter($this->client(), $this->getPrefix());
+    }
+}


### PR DESCRIPTION
## Description

Adds Redis-specific cache store implementations so that we can eventually support the richer set of configuration options and usages of the Redis store by Laravel.