### PR TITLE
fix: properly extract args from config

### DIFF
--- a/src/Cache/SymfonyCacheFactory.php
+++ b/src/Cache/SymfonyCacheFactory.php
@@ -53,7 +53,7 @@ class SymfonyCacheFactory
             throw new TypeError("unsupported redis adapter $desiredAdapter provided");
         }
 
-        $args = Arr::pluck($redisConfig, ['prefix', 'connection']);
+        $args = Arr::only($redisConfig, ['prefix', 'connection']);
 
         if ($desiredAdapter === RedisTagAwareAdapter::class || $tagAware) {
             return $this->container->make(SymfonyTagAwareRedisStore::class, $args);


### PR DESCRIPTION
## Description

Properly extract the arguments to pass into the Redis-specific stores.

Closes #20