### PR TITLE
test: add simple tests to check connection on redis-specific stores

### DIFF
--- a/tests/Feature/Cache/Redis/RedisCacheTest.php
+++ b/tests/Feature/Cache/Redis/RedisCacheTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature\Cache\Redis;
 
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Tests\Feature\Cache\CacheTestCase;
+use Trevorpe\LaravelSymfonyCache\Cache\SymfonyRedisStore;
 
 class RedisCacheTest extends CacheTestCase
 {
@@ -23,5 +25,23 @@ class RedisCacheTest extends CacheTestCase
             'connection' => env('REDIS_CACHE_CONNECTION', 'cache'),
             'prefix' => 'symfony'
         ]);
+    }
+
+    public function test_connection_is_set_to_cache()
+    {
+        /** @var SymfonyRedisStore $cache */
+        $cache = $this->symfonyCache()->getStore();
+
+        $this->assertEquals('cache', $cache->connection()->getName());
+    }
+
+    public function test_setting_connection_updates_redis_client()
+    {
+        /** @var SymfonyRedisStore $cache */
+        $cache = $this->symfonyCache()->getStore();
+
+        $cache->setConnection('default');
+
+        $this->assertEquals('default', $cache->connection()->getName());
     }
 }

--- a/tests/Feature/Cache/Redis/TagAwareRedisCacheTest.php
+++ b/tests/Feature/Cache/Redis/TagAwareRedisCacheTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Tests\Feature\Cache\TaggedCacheTestCase;
+use Trevorpe\LaravelSymfonyCache\Cache\SymfonyRedisStore;
 use Trevorpe\LaravelSymfonyCache\Cache\SymfonyTagAwareCacheStore;
 
 class TagAwareRedisCacheTest extends TaggedCacheTestCase
@@ -42,5 +43,23 @@ class TagAwareRedisCacheTest extends TaggedCacheTestCase
 
         // We expect it to remap to the more performance Redis adapter
         $this->assertInstanceOf(RedisTagAwareAdapter::class, $store->getAdapter());
+    }
+
+    public function test_connection_is_set_to_cache()
+    {
+        /** @var SymfonyRedisStore $cache */
+        $cache = $this->symfonyCache()->getStore();
+
+        $this->assertEquals('cache', $cache->connection()->getName());
+    }
+
+    public function test_setting_connection_updates_redis_client()
+    {
+        /** @var SymfonyRedisStore $cache */
+        $cache = $this->symfonyCache()->getStore();
+
+        $cache->setConnection('default');
+
+        $this->assertEquals('default', $cache->connection()->getName());
     }
 }


### PR DESCRIPTION
## Description

Since the Redis stores can accept a different connection after the fact, add a couple of tests to ensure that the connection names are as expected.